### PR TITLE
Add internal registry

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[registries]
+UefiRust = { index = "sparse+https://pkgs.dev.azure.com/microsoft/MsUEFI/_packaging/UefiRust/Cargo/index/" }
+
+[source.crates-io]
+replace-with = "UefiRust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mtrr"
 version = "0.1.0"
+publish = ["UefiRust"]
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "x64 MTRR programming library"


### PR DESCRIPTION
Pull crates from and publish to an internal feed until code is moved to open-source.