### PR TITLE
Change GitHub org name from pop-project to OpenDevicePartnership

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ publish = ["UefiRust"]
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "x64 MTRR programming library"
-repository = "https://github.com/pop-project/mtrr"
+repository = "https://github.com/OpenDevicePartnership/mtrr"
 keywords = ["mtrr"]
 
 [dependencies]


### PR DESCRIPTION
The org name has switched to OpenDevicePartnership so all references to the previous org name are updated.

---

- Verified new URLs.
- Note: "pop-project" will redirect to "OpenDevicePartnership" so the old URLs will still work for now.
  - https://github.com/pop-project will return 404 until/if it is claimed by someone else.