### PR TITLE
Cargo.toml: Allow bitfield-struct v0 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/OpenDevicePartnership/mtrr"
 keywords = ["mtrr"]
 
 [dependencies]
-bitfield-struct = "0.8.0"
-cfg-if = "1.0.0"
+bitfield-struct = "0.9"
+cfg-if = "1"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Allow compatibility across a broader version range to improve compatibility with downstream users of this library.

Before:

```
bitfield-struct v0.8.0 (proc-macro)
└── mtrr v0.1.0
    └── uefi_cpu v9.1.1
        ├── dxe_core v8.1.0
        │   └── intel_dxe_core v3.2.0
        ├── intel_dxe_core v3.2.0
        └── uefi_debugger v9.1.1
            └── dxe_core v8.1.0 (*)

bitfield-struct v0.9.5 (proc-macro)
├── intel_dxe_core v3.2.0
├── paging v1.0.2
│   ├── dxe_core v8.1.0 (*)
│   ├── uefi_cpu v9.1.1 (*)
│   └── uefi_debugger v9.1.1 (*)
└── uefi_debugger v9.1.1 (*)
```