### PR TITLE
rust-toolchain.toml: Add additional required components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 channel = "1.80.0"
-components = ["rust-src"]
+components = ["rust-src", "clippy", "rustfmt", "rust-docs"]
 
 [tools]
 cargo-make = "0.37.21"


### PR DESCRIPTION
## Description

These additional requirements must be specified so that the command `rustup toolchain install` installs all necessary components, just in case the user (or CI runner) does not have them installed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

https://github.com/OpenDevicePartnership/uefi-dxe-core/pull/287

## Integration Instructions

N/A