### PR TITLE
Makefile.toml: Add all, check, clippy, cspell, and fmt

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -69,6 +69,23 @@ clear = true
 command = "cargo"
 args = ["check", "--message-format=json"]
 
+[tasks.check_no_std]
+description = "Checks rust code for no_std build errors with results."
+private = true
+command = "cargo"
+args = ["check", "--target", "x86_64-unknown-uefi", "@@split(NO_STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check_std]
+description = "Checks rust code for std build errors with results."
+private = true
+command = "cargo"
+args = ["check", "@@split(STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
+[tasks.check]
+description = "Checks rust code for errors. Example `cargo make check`"
+clear = true
+run_task = [{ name = ["check_no_std", "check_std"], parallel = true }]
+
 [tasks.test]
 description = "Builds all rust tests in the workspace. Example `cargo make test`"
 clear = true
@@ -92,3 +109,27 @@ env = { RUSTDOCFLAGS = "-D warnings"}
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
 args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
+
+[tasks.fmt]
+description = "Run cargo format."
+clear = true
+command = "cargo"
+args = ["fmt", "--all"]
+
+[tasks.cspell]
+description = "Run cspell for spell checking." # npm install -g cspell@latest
+script = "cspell --quiet  --no-progress --no-summary  --dot --gitignore -e \"{.git/**,.github/**,.vscode/**}\" ."
+
+[tasks.all]
+description = "Run all tasks for PR readiness."
+dependencies = [
+    "clippy",
+    "cspell",
+    "build",
+    "build-x64",
+    "build-aarch64",
+    "test",
+    "coverage",
+    "fmt",
+    "doc",
+]


### PR DESCRIPTION
## Description

Adds additional commands present in other repos for consistency and convenience.

Adds the `all` command so a set of checks can be performed prior to PR like in other repos.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- `cargo make check`
- `cargo make clippy`
- `cargo make cspell`
- `cargo make fmt

## Integration Instructions

- N/A