### PR TITLE
Cargo.toml: Update to v0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "patina-mtrr"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "x64 MTRR programming library"


### PR DESCRIPTION
## Description

The version is updated to publish a new version to the `patina-fw` repo.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- N/A - Will be used to publish manually

## Integration Instructions

- This version will be published to the `patina-fw` registry feed:

  https://dev.azure.com/patina-fw/artifacts/_artifacts/feed/temporary

Since this repo is planned to start publishing to crates.io soon, the registry and token infrastructure in the repo are not updated for `patina-fw` and it will be published there manually.