### PR TITLE
Rename patina-mtrr crate to patina_mtrr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "patina-mtrr"
-version = "0.1.2"
+name = "patina_mtrr"
+version = "1.0.0"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 description = "x64 MTRR programming library"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,8 +4,8 @@ default_to_workspace = false
 [env]
 RUSTC_BOOTSTRAP = 1
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
-UEFI_CRATES = "-p patina-mtrr"
-BUILD_CRATES = "-p patina-mtrr"
+UEFI_CRATES = "-p patina_mtrr"
+BUILD_CRATES = "-p patina_mtrr"
 COV_FLAGS = { value = "--out html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
 
 [env.development]
@@ -29,7 +29,7 @@ Example:
 alias = "build-std"
 
 [tasks.build-std]
-description = """Builds patina-mtrr crate as std target.
+description = """Builds patina_mtrr crate as std target.
 
 Customizations:
     -p [development|release]: Builds in debug or release. Default: development
@@ -42,7 +42,7 @@ command = "cargo"
 args = ["build", "--profile", "${RUSTC_PROFILE}", "--features", "std", "--target", "${CARGO_MAKE_RUST_TARGET_TRIPLE}", "@@split(BUILD_CRATES, )", "@@split(UEFI_CRATES, )"]
 
 [tasks.build-x64]
-description = """Builds patina-mtrr crate as UEFI target.
+description = """Builds patina_mtrr crate as UEFI target.
 
 Example:
     `cargo make build-x64`
@@ -53,7 +53,7 @@ command = "cargo"
 args = ["build", "--target", "x86_64-unknown-uefi", "@@split(BUILD_FLAGS, )", "@@split(UEFI_CRATES, )"]
 
 [tasks.build-aarch64]
-description = """Builds patina-mtrr crate as UEFI target.
+description = """Builds patina_mtrr crate as UEFI target.
 
 Example:
     `cargo make build-aarch64`


### PR DESCRIPTION
## Description

Rename patina-mtrr crate to patina_mtrr to stay consistent with the [RFC](https://github.com/OpenDevicePartnership/patina/pull/408) and rest of the patina crates. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

Need to update in patina repo to refer to patina_mtrr instead of patina-mtrr in Cargo.toml files. Code remains the same.