### PR TITLE
Makefile.toml: Add check_tests subtask to check

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -81,10 +81,16 @@ private = true
 command = "cargo"
 args = ["check", "@@split(STD_FLAGS, )", "@@split(CARGO_MAKE_TASK_ARGS, )"]
 
+[tasks.check_tests]
+description = "Checks rust test code for build errors with results."
+private = true
+command = "cargo"
+args = ["test", "--no-run", "@@split(CARGO_MAKE_TASK_ARGS, )"]
+
 [tasks.check]
 description = "Checks rust code for errors. Example `cargo make check`"
 clear = true
-run_task = [{ name = ["check_no_std", "check_std"], parallel = true }]
+run_task = [{ name = ["check_no_std", "check_std", "check_tests"], parallel = true }]
 
 [tasks.test]
 description = "Builds all rust tests in the workspace. Example `cargo make test`"


### PR DESCRIPTION
## Description

This allows `cargo make check` to include test code. Since `cargo make check` is already run as the `Rust Analyzer` `check` command (as defined in `.vscode/settings.json`), this also allows the errors reported by Rust Analyzer in the `Problems` pane of VS Code to include test code errors when saving files.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Copied from Patina.

## Integration Instructions

N/A.
