### PR TITLE
Set rust analyze test env to use bootstrap

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,7 @@
     "."
   ],
   "rust-analyzer.cargo.targetDir": true,
+  "rust-analyzer.runnables.extraEnv": {
+    "RUSTC_BOOTSTRAP": "1"
+  },
 }


### PR DESCRIPTION
## Description

This is required to use rust analyzer uses the proper compiler for the tests run through the UI.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
