### PR TITLE
Gate coverage_attribute behind the coverage_nightly cfg [Rebase & FF]

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,9 +18,12 @@ RUSTC_BOOTSTRAP = "1"
 # they fail with E0725. If you must run `-Zbuild-std`, override rustflags for that invocation with
 # the RUSTFLAGS env var (which replaces these config rustflags), keeping everything else but dropping
 # `-Z allow-features`.
+#
+# Note: `coverage_attribute` is intentionally not in this list. It is only set in allow-features
+# when running coverage.
 [build]
 rustflags = [
-    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+    "-Z", "allow-features=c_variadic,allocator_api",
 ]
 
 [profile.dev]
@@ -78,7 +81,8 @@ rustflags = [
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
     # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
-    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+    # (coverage_attribute excluded on purpose; coverage runs add it via RUSTFLAGS)
+    "-Z", "allow-features=c_variadic,allocator_api",
 ]
 
 [target.aarch64-unknown-uefi]
@@ -90,5 +94,6 @@ rustflags = [
     # Preserve stack unwind info
     "-C", "force-unwind-tables",
     # Restrict the unstable features RUSTC_BOOTSTRAP unlocks to the accepted set
-    "-Z", "allow-features=c_variadic,allocator_api,coverage_attribute",
+    # (coverage_attribute excluded on purpose; coverage runs add it via RUSTFLAGS)
+    "-Z", "allow-features=c_variadic,allocator_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ std = []
 doc = []
 # All no_std features to test in CI
 ci_features = []
+
+[lints.rust]
+# Set by cargo-llvm-cov during coverage runs. Declared here so gating
+# `coverage_attribute` behind it does not trigger unexpected_cfgs warnings.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -206,6 +206,11 @@ args = ["test", "@@split(CARGO_MAKE_TASK_ARGS,;)"]
 description = "Run tests and collect coverage data without generating reports."
 install_crate = false
 clear = true
+# `coverage_attribute` is deliberately excluded from the default allow-features in
+# .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
+# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# Note: RUSTFLAGS replaces build.rustflags.
+env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"
 args = ["llvm-cov", "@@split(COV_FLAGS, )", "--no-report", "--doctests"]
 dependencies = ["llvm-cov-clean"]

--- a/cspell.yml
+++ b/cspell.yml
@@ -59,3 +59,4 @@ words:
   - wbinvd
   - wrmsr
   - wrpkru
+  - zbuild

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -62,7 +62,7 @@ impl Default for X64Hal {
     }
 }
 
-#[coverage(off)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(target_arch = "x86_64")]
 impl Hal for X64Hal {
     fn save_and_disable_interrupts(&mut self) -> bool {
@@ -236,7 +236,7 @@ impl Hal for X64Hal {
     }
 }
 
-#[coverage(off)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[cfg(not(target_arch = "x86_64"))]
 impl Hal for X64Hal {
     fn save_and_disable_interrupts(&mut self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@
 //!```
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(not(all(target_os = "uefi", target_arch = "aarch64")), feature(coverage_attribute))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 cfg_if::cfg_if! {
     if #[cfg(not(all(target_os = "uefi", target_arch = "aarch64")))] {
@@ -156,7 +156,7 @@ cfg_if::cfg_if! {
     }
 
     #[cfg(test)]
-    #[coverage(off)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     mod tests;
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -104,7 +104,7 @@ pub enum MtrrMemoryCacheType {
     Invalid = 7,
 }
 
-#[coverage(off)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 impl core::fmt::Display for MtrrMemoryCacheType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let type_str = match self {


### PR DESCRIPTION
## Description

cargo-llvm-cov sets the `coverage_nightly` cfg during coverage runs.

See the Readme: https://crates.io/crates/cargo-llvm-cov

This commit declares it once in `[workspace.lints.rust]` so crates can gate the unstable `coverage_attribute` feature behind it without causing the `unexpected_cfgs` lint to trigger.

Also wraps both the `coverage_attribute` feature gate and every `coverage(off)` attribute in `cfg_attr(coverage_nightly, ...)` so the unstable feature is active only during coverage runs, where cargo-llvm-cov sets the `coverage_nightly`cfg.

This is documented and the wrapping pattern is suggested in the cargo-llvm-cov Readme:

  > Since #[coverage(off)] is unstable, it is recommended to use it
  > together with cfg(coverage) or cfg(coverage_nightly) set by
  > cargo-llvm-cov.

  > ```rust
  > #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
  >
  > // function
  > #[cfg_attr(coverage_nightly, coverage(off))]
  > fn exclude_fn_from_coverage() {
  >     // ...
  > }
  >
  > // module
  > #[cfg_attr(coverage_nightly, coverage(off))]
  > mod exclude_mod_from_coverage {
  >     // ...
  > }
  > ```

This isolates the `coverage_attribute` feature to coverage runs, so the unstable feature is not used in other builds (e.g. `check`, `clippy`, `build`, `test`, etc.).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Testing with `RUSTC_BOOTSTRAP=1` and `allow-features` set without `coverage_attribute`, verified non-coverage commands like `cargo make test` and `cargo make check` succeed.

## Integration Instructions

- N/A