### PR TITLE
Switch from coverage_nightly to coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ ci_features = []
 [lints.rust]
 # Set by cargo-llvm-cov during coverage runs. Declared here so gating
 # `coverage_attribute` behind it does not trigger unexpected_cfgs warnings.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -208,7 +208,7 @@ install_crate = false
 clear = true
 # `coverage_attribute` is deliberately excluded from the default allow-features in
 # .cargo/config.toml so ungated `#[coverage(off)]` fails to compile. Coverage runs set the
-# `coverage_nightly` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
+# `coverage` cfg (set by cargo-llvm-cov), which needs the feature, so re-add it here.
 # Note: RUSTFLAGS replaces build.rustflags.
 env = { RUSTFLAGS = "-Z allow-features=c_variadic,allocator_api,coverage_attribute" }
 command = "cargo"

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -62,7 +62,7 @@ impl Default for X64Hal {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[cfg(target_arch = "x86_64")]
 impl Hal for X64Hal {
     fn save_and_disable_interrupts(&mut self) -> bool {
@@ -236,7 +236,7 @@ impl Hal for X64Hal {
     }
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 #[cfg(not(target_arch = "x86_64"))]
 impl Hal for X64Hal {
     fn save_and_disable_interrupts(&mut self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@
 //!```
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+#![cfg_attr(coverage, feature(coverage_attribute))]
 
 cfg_if::cfg_if! {
     if #[cfg(not(all(target_os = "uefi", target_arch = "aarch64")))] {
@@ -156,7 +156,7 @@ cfg_if::cfg_if! {
     }
 
     #[cfg(test)]
-    #[cfg_attr(coverage_nightly, coverage(off))]
+    #[cfg_attr(coverage, coverage(off))]
     mod tests;
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -104,7 +104,7 @@ pub enum MtrrMemoryCacheType {
     Invalid = 7,
 }
 
-#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg_attr(coverage, coverage(off))]
 impl core::fmt::Display for MtrrMemoryCacheType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let type_str = match self {


### PR DESCRIPTION
## Description

Since the repo is currently using the stable toolchain, switch from gating `coverage_attribute` on `coverage_nightly` to `coverage` per https://github.com/taiki-e/cargo-llvm-cov.

This is set automatically by `cargo-llvm-cov`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make coverage`

Checked the environment configured by `cargo-llvm-cov` in my local workspace:

```
❯ cargo llvm-cov show-env
info: cargo-llvm-cov currently setting cfg(coverage); you can opt-out it by passing --no-cfg-coverage
RUSTFLAGS="-Z allow-features=c_variadic,allocator_api -C instrument-coverage --cfg=coverage --cfg=trybuild_no_target"
LLVM_PROFILE_FILE=patina-mtrr\target\patina-mtrr-%p-%16m.profraw
CARGO_LLVM_COV=1
CARGO_LLVM_COV_SHOW_ENV=1
CARGO_LLVM_COV_TARGET_DIR=patina-mtrr\targe
```

## Integration Instructions

- N/A

---

- patina-devops synced files will be updated in a single PR in that repo.
