### PR TITLE
Variable MTRR setting calculation problem

### DIFF
--- a/src/mtrr.rs
+++ b/src/mtrr.rs
@@ -1786,7 +1786,7 @@ impl<H: Hal> MtrrLib<H> {
                 //      Buffer Too Small may be returned if the scratch buffer size is insufficient.
                 self.mtrr_lib_set_memory_ranges(
                     default_type,
-                    1 << high_bit_set_64(mtrr_valid_bits_mask),
+                    1 << high_bit_set_64(mtrr_valid_bits_mask + 1),
                     &mut working_ranges,
                     working_range_count,
                     scratch,


### PR DESCRIPTION
## Description
 - mtrr_valid_bits_mask = (1 << physical_address_bits) - 1, i.e. all N low bits set, where N = CPU-reported physical address bits.
 - high_bit_set_64(mtrr_valid_bits_mask) returns the index of the highest set bit, which is N-1 for a mask with N bits set.
 - So 1 << (N-1) is a half of the true total address space (mtrr_valid_bits_mask + 1 = 2^N).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
the current MTRR settings:
Variable MTRR[00]: Base=0x00000000FF000000 Mask=0x0000007FFF000000 Type=5
Variable MTRR[01]: Base=0x0000000000000000 Mask=0x0000007F80000000 Type=6
Variable MTRR[02]: Base=0x000000007A000000 Mask=0x0000007FFE000000 Type=0
Variable MTRR[03]: Base=0x000000007C000000 Mask=0x0000007FFC000000 Type=0
Variable MTRR[04]: Base=0x0000000100000000 Mask=0x0000007F00000000 Type=6
Variable MTRR[05]: Base=0x0000000200000000 Mask=0x0000007E00000000 Type=6

A call  gDS->SetMemorySpaceAttributes (EFI_MEMORY_WB at 0x7A000000, size 0x2000000) causes panic for "MTRR vertex order violation"

## Integration Instructions
- changed mtrr.rs
